### PR TITLE
Put docker setup in its own section in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 - Docker and docker-compose if running the system or the database from a container
 - For running without docker: Set up a Postgres instance on port 5432
 
-# Setup
+# Setup (Run locally/on host machine)
+
+This method 
 
 1. Create a python environment (one time instruction):
 `python3 -m venv env`
@@ -18,22 +20,33 @@
 3. Install the requirements (one time instruction):
 `pip install -r requirements.txt`
 
-4. If you run the server locally, set up the database for local development
+4. Set up the database via docker or connect your own Postgres instance
 `docker-compose up db`
 
-5. Run the server from the root folder:
+5. Run the migrations from the root folder:
+`python src/manage.py migrate`
+
+6. Run the server from the root folder:
 `python src/manage.py runserver` The server runs on http://127.0.0.1:8000/
 
-6. Run the tests:
+7. To run the tests:
 `python src/manage.py test`
 
-7. Run pylint:
+8. To run pylint:
 `find src -name "*.py" | xargs pylint`
 
-8. Simulate a deployment locally with Django debug mode enabled (runs on port 8000):
+# Setup (Run via docker)
+
+This method should be sufficient for most development tasks as any (file) changes you make are monitored by StatReloader. To start the environment, run:
 `docker-compose up --build`
 
 Note: remove `--build` to skip building the container, will use the cached one (last build)
+
+After this, you can access the application on http://127.0.0.1:8000/ and a pgAdmin instance on http://127.0.0.1:5050/ with `admin@admin.com:admin` for username:password. From pgAdmin add a new server by giving it a name and the following database credentials:
+
+![image](https://user-images.githubusercontent.com/15870306/145728488-ada8aacf-ec53-42d1-8e4d-b7198c70cc77.png)
+
+
 
 # Deployment
 


### PR DESCRIPTION
A developer only needs to use one of these two methods, and this adjusts the readme to reflect that