### PR TITLE
Add restarts to the docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-delfitlm}
       - POSTGRES_USER=${POSTGRES_DB:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_DB:-postgres}
+    restart: always
   
   app:
     build:
@@ -21,6 +22,7 @@ services:
         - POSTGRES_PASSWORD=${POSTGRES_DB:-postgres}
         - POSTGRES_HOST=${POSTGRES_DB:-db}
         - POSTGRES_PORT=${POSTGRES_DB:-5432}
+    restart: always
     depends_on:
       - "db"
 


### PR DESCRIPTION
I found a few times that running `docker-compose up --build` would start the app before the database finished initializing and would exit() the app. This solves that plus any eventual other issues with the app or db exiting without restarting