### PR TITLE
49 add email sending support

### DIFF
--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: '3.7'
 
 services:
     app:
@@ -8,8 +8,11 @@ services:
             # TODO: change the key
             # could also add database config here and remove it from settings.py
             - DEBUG=0
-            - SECRET_KEY=qwerty
-            - ALLOWED_HOSTS=localhost,127.0.0.1
+            - SECRET_KEY=${SECRET_KEY:-qwerty}
+            - ALLOWED_HOSTS=${ALLOWED_HOSTS:-localhost,127.0.0.1}
+            - SMTP_HOST=${SMTP_HOST}
+            - SMTP_PORT=${SMTP_PORT}
+            - FROM_EMAIL=${FROM_EMAIL}
     proxy:
         build:
             context: ./proxy

--- a/src/delfitlm/settings.py
+++ b/src/delfitlm/settings.py
@@ -30,6 +30,13 @@ POSTGRES_PASSWORD   = os.environ.get('POSTGRES_PASSWORD', 'postgres')
 POSTGRES_HOST       = os.environ.get('POSTGRES_HOST', 'localhost')
 POSTGRES_PORT       = int(os.environ.get('POSTGRES_PORT', 5432))
 
+# configure the email backend to relay email
+EMAIL_BACKEND           = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST              = os.environ.get('SMTP_HOST', '')
+EMAIL_PORT              = os.environ.get('SMTP_PORT, '25')
+EMAIL_HOST_USER         = os.environ.get('SMTP_USER, '')
+EMAIL_HOST_PASSWORD     = os.environ.get('SMTP_PASSWORD, '')
+EMAIL_USE_TLS           = False
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(int(os.environ.get('DEBUG', 1)))

--- a/src/delfitlm/settings.py
+++ b/src/delfitlm/settings.py
@@ -33,9 +33,9 @@ POSTGRES_PORT       = int(os.environ.get('POSTGRES_PORT', 5432))
 # configure the email backend to relay email
 EMAIL_BACKEND           = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST              = os.environ.get('SMTP_HOST', '')
-EMAIL_PORT              = os.environ.get('SMTP_PORT, '25')
-EMAIL_HOST_USER         = os.environ.get('SMTP_USER, '')
-EMAIL_HOST_PASSWORD     = os.environ.get('SMTP_PASSWORD, '')
+EMAIL_PORT              = int(os.environ.get('SMTP_PORT', 25))
+EMAIL_HOST_USER         = os.environ.get('SMTP_USER', '')
+EMAIL_HOST_PASSWORD     = os.environ.get('SMTP_PASSWORD', '')
 EMAIL_USE_TLS           = False
 
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/src/delfitlm/settings.py
+++ b/src/delfitlm/settings.py
@@ -38,6 +38,9 @@ EMAIL_HOST_USER         = os.environ.get('SMTP_USER', '')
 EMAIL_HOST_PASSWORD     = os.environ.get('SMTP_PASSWORD', '')
 EMAIL_USE_TLS           = False
 
+if EMAIL_HOST is '':
+    EMAIL_BACKEND       = 'django.core.mail.backends.console.EmailBackend'
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = bool(int(os.environ.get('DEBUG', 1)))
 

--- a/src/members/views.py
+++ b/src/members/views.py
@@ -31,7 +31,9 @@ def register(request):
                     )
             send_mail(
                 'Welcome to the DelfiTLM portal!',
-                'Dear ' + user.username + ',\n thank you for joining the DelfiTLM portal: with this portal, you can submit telemetry for all the DelfiSpace satellites. ',
+                'Dear ' + user.username +
+                ',\n thank you for joining the DelfiTLM portal: with this portal,'
+                ' you can submit telemetry for all the DelfiSpace satellites. ',
                 os.environ.get('EMAIL_FROM',''),
                 [user.email],
                 fail_silently=True,

--- a/src/members/views.py
+++ b/src/members/views.py
@@ -1,10 +1,12 @@
 """API request handling. Map requests to the corresponding HTMLs."""
+import os
 from django.utils import timezone
 from django.shortcuts import redirect, render
 from django.contrib.auth import login, authenticate, logout
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import update_session_auth_hash
+from django.core.mail import send_mail
 from .forms import RegisterForm, LoginForm, ChangePasswordForm
 from .models import Member
 
@@ -27,6 +29,13 @@ def register(request):
                         date_joined=timezone.now(),
                         last_login=timezone.now()
                     )
+            send_mail(
+                'Welcome to the DelfiTLM portal!',
+                'Dear ' + user.username + ',\n thank you for joining the DelfiTLM portal: with this portal, you can submit telemetry for all the DelfiSpace satellites. ',
+                os.environ.get('EMAIL_FROM',''),
+                [user.email],
+                fail_silently=True,
+                )
             return render(request, "members/home/profile.html")
         messages.error(request, "Unsuccessful registration. Invalid information.")
 


### PR DESCRIPTION
Adding basic email sending capabilities. This branch is based on #45 and it adds a very basic email being sent after the user successfully registers. The email text should probably be improved (together with basic email verification, as in #28) but this branch can act as a starting point.

This branch requires an external unencrypted SMTP server to send emails: this branch has been deployed on the telemetry virtual server and sends emails successfully upon new user registration). SMTP server configuration is done via an external env file containing the private email server details.