### PR TITLE
Make pgadmin settings persistent and set pgadmin version to 6.4

### DIFF
--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -13,11 +13,13 @@ services:
             - SMTP_HOST=${SMTP_HOST}
             - SMTP_PORT=${SMTP_PORT}
             - FROM_EMAIL=${FROM_EMAIL}
+        restart: always
+
     proxy:
         build:
             context: ./proxy
         volumes:
-                - certificates:/certs:ro
+            - certificates:/certs:ro
         ports:
             - "80:8080"
             - "443:8443"
@@ -26,16 +28,21 @@ services:
         depends_on:
             - app
             - pgadmin
+        restart: always
 
     pgadmin:
         container_name: pgadmin4_container
-        image: dpage/pgadmin4
+        image: dpage/pgadmin4:6.4
         restart: always
         environment:
             - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL:-admin@admin.com}
             - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD:-admin}
         depends_on:
             - "db"
+        volumes:
+            - pgadmin_persistent:/var/lib/pgadmin
+
 volumes:
     static_data:
     certificates:
+    pgadmin_persistent:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,7 +18,7 @@ services:
 
   pgadmin:
     container_name: pgadmin4_container
-    image: dpage/pgadmin4
+    image: dpage/pgadmin4:6.4
     restart: always
     environment:
       PGADMIN_DEFAULT_EMAIL: admin@admin.com


### PR DESCRIPTION
Making pgadmin data storage persistent. This way we just set the database settings once.
Also setting pgadmin to version 6.4 (the latest version to ease future maintenance).