### PR TITLE
Fix invalid literal for int() error

### DIFF
--- a/src/delfitlm/settings.py
+++ b/src/delfitlm/settings.py
@@ -34,7 +34,12 @@ POSTGRES_PORT       = int(os.environ.get('POSTGRES_PORT', 5432))
 # configure the email backend to relay email
 EMAIL_BACKEND           = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST              = os.environ.get('SMTP_HOST', '')
-EMAIL_PORT              = int(os.environ.get('SMTP_PORT', 25))
+
+if os.environ.get('SMTP_PORT') in ['', None]:
+    EMAIL_PORT          = 25
+else:
+    EMAIL_PORT          = int(os.environ.get('SMTP_PORT'))
+
 EMAIL_HOST_USER         = os.environ.get('SMTP_USER', '')
 EMAIL_HOST_PASSWORD     = os.environ.get('SMTP_PASSWORD', '')
 EMAIL_USE_TLS           = False


### PR DESCRIPTION
Fix error when os.environ.get('SMTP_PORT') is an empty string and casting to int fails.