### PR TITLE
Fix the migration conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 uWSGI>=2.0.18,<2.1
 asgiref==3.4.1
 astroid==2.8.0
-Django==3.2.8
+Django==3.2.12
 django-pandas==0.6.6
 djangorestframework==3.13.1
 djangorestframework-api-key==2.1.0


### PR DESCRIPTION
Django 3.2.8 has a bug in the [migration order policy](https://docs.djangoproject.com/en/4.0/releases/3.2.9/)  (only alphabetic order, dependencies are ignored). Upgrading to a newer version of Django fixes the problem automatically.