### PR TITLE
Fix hardcoded hostname

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -7,8 +7,8 @@ RUN UID=`whoami`
 # switch to root
 USER root
 
-COPY ./http.conf /http.conf
-COPY ./https.conf.template /default.conf.template
+COPY ./http.conf.template /http.conf.template
+COPY ./https.conf.template /https.conf.template
 COPY ./uwsgi_params /etc/nginx/uwsgi_params
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/proxy/entrypoint.sh
+++ b/proxy/entrypoint.sh
@@ -4,19 +4,21 @@
 CERTIFICATE=/certs/server.pem
 KEY=/certs/server.key
 
+# this is used to resolve the $host strings in the nginx conf file
+export DOLLAR='$'
+    
 # check if the certificates exist
 if [ -f "$CERTIFICATE" ] && [ -f "$KEY" ];
 then
     echo "Certificates found... using HTTPS configuration"
 
-    # this is used to resolve the $host strings in the nginx conf file
-    export DOLLAR='$'
-
     # replace environment variables in the nginx configuration file
-    envsubst < /default.conf.template > /etc/nginx/conf.d/default.conf
+    envsubst < /https.conf.template > /etc/nginx/conf.d/default.conf
 else
     echo "Certificates not found... using HTTP configuration"
-    cp /http.conf /etc/nginx/conf.d/default.conf
+    
+    # replace environment variables in the nginx configuration file
+    envsubst < /http.conf.template > /etc/nginx/conf.d/default.conf
 fi
 
 # start nginx

--- a/proxy/http.conf.template
+++ b/proxy/http.conf.template
@@ -12,7 +12,7 @@ server {
 
     location /dbmanager/ {
         proxy_set_header X-Script-Name /dbmanager;
-        proxy_set_header Host delfitlm.tudelft.nl;
+        proxy_set_header Host ${MY_HOST};
         proxy_pass http://pgadmin/;
         proxy_redirect off;
     }


### PR DESCRIPTION
Fixing a hardcoded hostname: now the name is passed as environment variable and replaced befor nginx starts.