### PR TITLE
Fixing from email in automatic emails

### DIFF
--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -12,7 +12,7 @@ services:
             - ALLOWED_HOSTS=${MY_HOST:-localhost,127.0.0.1}
             - SMTP_HOST=${SMTP_HOST}
             - SMTP_PORT=${SMTP_PORT}
-            - FROM_EMAIL=${FROM_EMAIL}
+            - FROM_EMAIL=${FROM_EMAIL:-webmaster@localhost}
         restart: always
 
     proxy:

--- a/src/delfitlm/settings.py
+++ b/src/delfitlm/settings.py
@@ -43,6 +43,7 @@ else:
 EMAIL_HOST_USER         = os.environ.get('SMTP_USER', '')
 EMAIL_HOST_PASSWORD     = os.environ.get('SMTP_PASSWORD', '')
 EMAIL_USE_TLS           = False
+DEFAULT_FROM_EMAIL      = os.environ.get('FROM_EMAIL', 'webmaster@localhost')
 
 if EMAIL_HOST == '':
     EMAIL_BACKEND       = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
The 'From' email field was not correctly fetched from the environmental variables. In case of a missing variable, the default value would cause an error 500 on the login / registration page. 

A valid default email address is used to prevent the error if the email address is not correctly provided.

Closes #49