### PR TITLE
Update https.conf.template

### DIFF
--- a/proxy/https.conf.template
+++ b/proxy/https.conf.template
@@ -9,7 +9,8 @@ server {
 
 # HTTPS configuration
 server {
-    listen 8443 ssl http2;
+    listen 8443 ssl;
+    http2 on;
 
     server_name ${MY_HOST};
 
@@ -69,7 +70,8 @@ server {
 
 # forwarded influxdb-cli HTTPS configuration
 server {
-    listen 8081 ssl http2;
+    listen 8081 ssl;
+    http2 on;
 
     server_name ${MY_HOST};
 
@@ -100,7 +102,8 @@ server {
 
 # forwarded pgadmin HTTPS configuration
 server {
-    listen 8082 ssl http2;
+    listen 8082 ssl;
+    http2 on;
 
     server_name ${MY_HOST};
 


### PR DESCRIPTION
Fixing deprecation warnings for nginx >1.25.1
This patch fixes issue #128.

Test pending still...